### PR TITLE
Json formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Mustache Template Engine for Go
 
 [![Build Status](https://img.shields.io/travis/cbroglie/mustache.svg)](https://travis-ci.org/cbroglie/mustache)
-[![Go Doc](https://godoc.org/github.com/cbroglie/mustache?status.svg)](https://godoc.org/github.com/cbroglie/mustache)
-[![Go Report Card](https://goreportcard.com/badge/github.com/cbroglie/mustache)](https://goreportcard.com/report/github.com/cbroglie/mustache)
+[![Go Doc](https://godoc.org/github.com/verloop/mustache?status.svg)](https://godoc.org/github.com/verloop/mustache)
+[![Go Report Card](https://goreportcard.com/badge/github.com/verloop/mustache)](https://goreportcard.com/report/github.com/verloop/mustache)
 [![codecov](https://codecov.io/gh/cbroglie/mustache/branch/master/graph/badge.svg)](https://codecov.io/gh/cbroglie/mustache)
-[![Downloads](https://img.shields.io/github/downloads/cbroglie/mustache/latest/total.svg)](https://github.com/cbroglie/mustache/releases)
-[![Latest release](https://img.shields.io/github/release/cbroglie/mustache.svg)](https://github.com/cbroglie/mustache/releases)
+[![Downloads](https://img.shields.io/github/downloads/cbroglie/mustache/latest/total.svg)](https://github.com/verloop/mustache/releases)
+[![Latest release](https://img.shields.io/github/release/cbroglie/mustache.svg)](https://github.com/verloop/mustache/releases)
 
 
 <img src="./images/logo.jpeg" alt="logo" width="100"/>
@@ -24,7 +24,7 @@ I forked [hoisie/mustache](https://github.com/hoisie/mustache) because it does n
 ## CLI Overview
 
 ```bash
-➜  ~ go install github.com/cbroglie/mustache/cmd/mustache@latest
+➜  ~ go install github.com/verloop/mustache/cmd/mustache@latest
 ➜  ~ mustache
 Usage:
   mustache [data] template [flags]
@@ -64,7 +64,7 @@ Also check out some [example mustache files](http://github.com/mustache/mustache
 
 ## Installation
 
-To install the CLI, run `go install github.com/cbroglie/mustache/cmd/mustache@latest`. To use it in a program, run `go get github.com/cbroglie/mustache` and use `import "github.com/cbroglie/mustache"`.
+To install the CLI, run `go install github.com/verloop/mustache/cmd/mustache@latest`. To use it in a program, run `go get github.com/verloop/mustache` and use `import "github.com/verloop/mustache"`.
 
 ----
 

--- a/cmd/mustache/main.go
+++ b/cmd/mustache/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/cbroglie/mustache"
+	"github.com/verloop/mustache"
 )
 
 var rootCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/cbroglie/mustache
+module github.com/verloop/mustache
 
-go 1.20
+go 1.21
 
 require (
 	github.com/spf13/cobra v1.7.0

--- a/mustache.go
+++ b/mustache.go
@@ -699,7 +699,7 @@ func (tmpl *Template) renderElement(element interface{}, contextChain []interfac
 		if val.IsValid() {
 			if elem.raw {
 				switch reflect.TypeOf(val.Interface()).Kind() {
-				case reflect.Slice, reflect.Map:
+				case reflect.Slice, reflect.Map, reflect.Array:
 					marshalledJson, err := json.Marshal(val.Interface())
 					if err != nil {
 						return err

--- a/mustache.go
+++ b/mustache.go
@@ -2,6 +2,7 @@ package mustache
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
@@ -697,7 +698,16 @@ func (tmpl *Template) renderElement(element interface{}, contextChain []interfac
 
 		if val.IsValid() {
 			if elem.raw {
-				fmt.Fprint(buf, val.Interface())
+				switch reflect.TypeOf(val.Interface()).Kind() {
+				case reflect.Slice, reflect.Map:
+					marshalledJson, err := json.Marshal(val.Interface())
+					if err != nil {
+						return err
+					}
+					buf.Write(marshalledJson)
+				default:
+					fmt.Fprint(buf, val.Interface())
+				}
 			} else {
 				s := fmt.Sprint(val.Interface())
 				_, _ = buf.Write([]byte(tmpl.escape(s)))


### PR DESCRIPTION
use json formatter for slice, array and map type values instead of default go formatter which uses space separator instead of comma